### PR TITLE
Fix spelling errors and gate EbuR128C use on c-tests feature

### DIFF
--- a/benches/ebur128.rs
+++ b/benches/ebur128.rs
@@ -1,8 +1,10 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 use ebur128::{EbuR128, Mode};
-use ebur128_c::EbuR128 as EbuR128C;
 use ebur128_c::Mode as ModeC;
+
+#[cfg(feature = "c-tests")]
+use ebur128_c::EbuR128 as EbuR128C;
 
 #[cfg(feature = "c-tests")]
 fn get_results_c(ebu: &EbuR128C, mode: ModeC) {

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -25,7 +25,7 @@ use crate::ebur128::Channel;
 
 pub struct Filter {
     channels: u32,
-    // BS.1770 filter coefficients (nominator).
+    // BS.1770 filter coefficients (numerator).
     b: [f64; 5],
     // BS.1770 filter coefficients (denominator).
     a: [f64; 5],
@@ -84,7 +84,7 @@ fn filter_coefficients(rate: f64) -> ([f64; 5], [f64; 5]) {
     ra[2] = (1.0 - K / Q + K * K) / (1.0 + K / Q + K * K);
 
     (
-        // Nominator
+        // Numerator
         [
             pb[0] * rb[0],
             pb[0] * rb[1] + pb[1] * rb[0],

--- a/tests/c/filter.c
+++ b/tests/c/filter.c
@@ -25,7 +25,7 @@ typedef struct {
   unsigned int rate;
   unsigned int channels;
 
-  /** BS.1770 filter coefficients (nominator). */
+  /** BS.1770 filter coefficients (numerator). */
   double b[5];
   /** BS.1770 filter coefficients (denominator). */
   double a[5];


### PR DESCRIPTION
Fixes some minor mistakes. Specifically:

- fractions are numerator / denominator, not nominator / denominator
- `ebur128_c::EbuR128` is not used in benches/ebur128.rs, remove `use`