### PR TITLE
Address numeric types constants via std instead of just the type

### DIFF
--- a/src/ebur128.rs
+++ b/src/ebur128.rs
@@ -271,7 +271,7 @@ impl EbuR128 {
         let sample_peak = vec![0.0; channels as usize];
         let true_peak = vec![0.0; channels as usize];
 
-        let history = usize::MAX;
+        let history = std::usize::MAX;
         let samples_in_100ms = (rate as usize + 5) / 10;
 
         let window = if mode.contains(Mode::S) {
@@ -710,7 +710,7 @@ impl EbuR128 {
         let energy = self.energy_in_interval(self.samples_in_100ms * 4)?;
 
         if energy <= 0.0 {
-            return Ok(-f64::INFINITY);
+            return Ok(-std::f64::INFINITY);
         }
 
         Ok(energy_to_loudness(energy))
@@ -725,7 +725,7 @@ impl EbuR128 {
         let energy = self.energy_shortterm()?;
 
         if energy <= 0.0 {
-            return Ok(-f64::INFINITY);
+            return Ok(-std::f64::INFINITY);
         }
 
         Ok(energy_to_loudness(energy))
@@ -743,7 +743,7 @@ impl EbuR128 {
         let energy = self.energy_in_interval(interval_frames)?;
 
         if energy <= 0.0 {
-            return Ok(-f64::INFINITY);
+            return Ok(-std::f64::INFINITY);
         }
 
         Ok(energy_to_loudness(energy))

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -222,7 +222,7 @@ impl Filter {
 
             if ftz.is_none() {
                 for v in filter_state {
-                    if v.abs() < f64::EPSILON {
+                    if v.abs() < std::f64::EPSILON {
                         *v = 0.0;
                     }
                 }

--- a/src/history.rs
+++ b/src/history.rs
@@ -287,7 +287,7 @@ impl History {
         });
 
         if above_thresh_counter == 0 {
-            return -f64::INFINITY;
+            return -std::f64::INFINITY;
         }
 
         let relative_gate = -10.0;
@@ -332,7 +332,7 @@ impl History {
         }
 
         if above_thresh_counter == 0 {
-            return -f64::INFINITY;
+            return -std::f64::INFINITY;
         }
 
         energy_to_loudness(gated_loudness / above_thresh_counter as f64)


### PR DESCRIPTION
Otherwise we won't compile anymore with older Rust versions.
With this we any version starting at 1.32.0.