### PR TITLE
Only allow a single channel when DualMono is used in set_channel_map()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ specifically the [variant used by Rust](http://doc.crates.io/manifest.html#the-v
 ### Fixed
 - Fix build with the MSVC toolchain.
 
-## [0.1.0] - 2020-01-06
+## 0.1.0 - 2020-01-06
 - Initial release of ebur128.
 
 [Unreleased]: https://github.com/sdroege/rust-muldiv/compare/0.1.4...HEAD

--- a/src/ebur128.rs
+++ b/src/ebur128.rs
@@ -410,6 +410,12 @@ impl EbuR128 {
             return Err(Error::InvalidChannelIndex);
         }
 
+        for (channel_number, value) in channel_map.iter().enumerate() {
+            if *value == Channel::DualMono && (self.channels != 1 || channel_number != 0) {
+                return Err(Error::InvalidChannelIndex);
+            }
+        }
+
         self.channel_map.copy_from_slice(channel_map);
         Ok(())
     }


### PR DESCRIPTION
The same check also exists in set_channel() and it would be inconsistent to not repeat it here.