### PR TITLE
Get rid of unsafe code in Histogram handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ readme = "README.md"
 [dependencies]
 bitflags = "1.0"
 smallvec = "1.0"
+once_cell = "1.0"
 
 [build-dependencies]
 cc = { version = "1.0", optional = true }


### PR DESCRIPTION
And replace it by using once_cell and passing around a static reference
to the histogram metadata in various places.

While this decreases performance of the benchmark that tests addition of
1M values into the histogram by about 12% it has no measurable impact on
any of the other benchmarks, and most importantly has no measurable
impact when used as part of the whole EbuR128 benchmarks.

Once f64::powf() becomes a const function we can get rid of this
entirely and have it all static.