### PR TITLE
Bufferless True Peak-analysis

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ readme = "README.md"
 [dependencies]
 bitflags = "1.0"
 smallvec = "1.0"
+dasp_sample = "0.11"
+dasp_frame = "0.11"
 
 [build-dependencies]
 cc = { version = "1.0", optional = true }

--- a/benches/interp.rs
+++ b/benches/interp.rs
@@ -31,11 +31,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     }
     group.bench_function("Rust", |b| {
         b.iter(|| {
-            let interp = interp::Interp::new(
-                black_box(49),
-                black_box(data_out.len() / data.len()),
-                black_box(2),
-            );
+            let interp = interp::Interp2F::<[f32; 4]>::new();
             drop(black_box(interp));
         })
     });
@@ -59,14 +55,16 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         interp::interp_destroy_c(interp);
     }
     {
-        let mut interp = interp::Interp::new(
-            black_box(49),
-            black_box(data_out.len() / data.len()),
-            black_box(2),
-        );
+        let mut interp = interp::Interp2F::new();
+        let (_, data, _) = unsafe { data.align_to::<[f32; 2]>() };
+        let (_, data_out, _) = unsafe { data_out.align_to_mut::<[f32; 2]>() };
         group.bench_function("Rust", |b| {
             b.iter(|| {
-                interp.process(&data, &mut data_out);
+                for (input_frame, output_frames) in
+                    Iterator::zip(data.iter(), data_out.chunks_exact_mut(2))
+                {
+                    output_frames.copy_from_slice(&interp.interpolate(*input_frame));
+                }
             })
         });
     }
@@ -91,14 +89,16 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         interp::interp_destroy_c(interp);
     }
     {
-        let mut interp = interp::Interp::new(
-            black_box(49),
-            black_box(data_out.len() / data.len()),
-            black_box(2),
-        );
+        let mut interp = interp::Interp4F::new();
+        let (_, data, _) = unsafe { data.align_to::<[f32; 2]>() };
+        let (_, data_out, _) = unsafe { data_out.align_to_mut::<[f32; 2]>() };
         group.bench_function("Rust", |b| {
             b.iter(|| {
-                interp.process(&data, &mut data_out);
+                for (input_frame, output_frames) in
+                    Iterator::zip(data.iter(), data_out.chunks_exact_mut(4))
+                {
+                    output_frames.copy_from_slice(&interp.interpolate(*input_frame));
+                }
             })
         });
     }

--- a/src/ebur128.rs
+++ b/src/ebur128.rs
@@ -20,6 +20,7 @@
 // THE SOFTWARE.
 
 use crate::energy_to_loudness;
+use crate::utils::Sample;
 
 use bitflags::bitflags;
 
@@ -572,7 +573,7 @@ impl EbuR128 {
 
     /// Process frames. This is the generic variant of the different public add_frames() functions
     /// that are defined below.
-    fn add_frames<'a, T: crate::AsF64 + 'a, S: crate::Samples<'a, T>>(
+    fn add_frames<'a, T: Sample + 'a, S: crate::Samples<'a, T>>(
         &mut self,
         mut src: S,
     ) -> Result<(), Error> {

--- a/src/ebur128.rs
+++ b/src/ebur128.rs
@@ -2018,13 +2018,13 @@ mod tests {
                 ebu.true_peak(c).unwrap(),
                 ebu_c.true_peak(c).unwrap(),
                 // For a performance-boost, filter is defined as f32, causing slightly lower precision
-                abs <= 0.000002,
+                abs <= 0.000004,
             );
             assert_float_eq!(
                 ebu.prev_true_peak(c).unwrap(),
                 ebu_c.prev_true_peak(c).unwrap(),
                 // For a performance-boost, filter is defined as f32, causing slightly lower precision
-                abs <= 0.000002,
+                abs <= 0.000004,
             );
         }
 

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -471,7 +471,7 @@ mod tests {
                     *r,
                     *c,
                     // For a performance-boost, filter is defined as f32, causing slightly lower precision
-                    abs <= 0.000002,
+                    abs <= 0.000004,
                     "Rust and C implementation differ at true peak {}",
                     i
                 );

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -19,555 +19,101 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-trait Interpolator: std::fmt::Debug {
-    fn process(&mut self, src: &[f32], dst: &mut [f32]);
-    fn reset(&mut self);
-    fn get_factor(&self) -> usize;
-}
+use crate::utils::FrameAccumulator;
+use std::f64::consts::PI;
 
-#[derive(Debug)]
-pub struct Interp(Box<dyn Interpolator>);
+const ALMOST_ZERO: f64 = 0.000001;
+const TAPS: usize = 48;
 
-impl Interp {
-    pub fn new(taps: usize, factor: usize, channels: u32) -> Self {
-        let imp: Box<dyn Interpolator> = match (taps, factor, channels) {
-            (49, 2, 1) => Box::new(specialized::Interp2F::<[f32; 1]>::new()),
-            (49, 2, 2) => Box::new(specialized::Interp2F::<[f32; 2]>::new()),
-            (49, 2, 4) => Box::new(specialized::Interp2F::<[f32; 4]>::new()),
-            (49, 2, 6) => Box::new(specialized::Interp2F::<[f32; 6]>::new()),
-            (49, 2, 8) => Box::new(specialized::Interp2F::<[f32; 8]>::new()),
-            (49, 4, 1) => Box::new(specialized::Interp4F::<[f32; 1]>::new()),
-            (49, 4, 2) => Box::new(specialized::Interp4F::<[f32; 2]>::new()),
-            (49, 4, 4) => Box::new(specialized::Interp4F::<[f32; 4]>::new()),
-            (49, 4, 6) => Box::new(specialized::Interp4F::<[f32; 6]>::new()),
-            (49, 4, 8) => Box::new(specialized::Interp4F::<[f32; 8]>::new()),
-            (taps, factor, channels) => Box::new(generic::Interp::new(taps, factor, channels)),
-        };
-        Self(imp)
-    }
+macro_rules! interp_impl {
+    ( $name:ident, $factor:expr ) => {
+        #[derive(Debug, Clone)]
+        pub struct $name<F: FrameAccumulator> {
+            filter: [[f32; $factor]; (TAPS / $factor)],
+            buffer: [F; (TAPS / $factor)],
+            buffer_pos: usize,
+        }
 
-    pub fn process(&mut self, src: &[f32], dst: &mut [f32]) {
-        self.0.process(src, dst)
-    }
-
-    pub fn reset(&mut self) {
-        self.0.reset()
-    }
-
-    pub fn get_factor(&self) -> usize {
-        self.0.get_factor()
-    }
-}
-
-mod generic {
-    use smallvec::SmallVec;
-    use std::f64;
-    /// Data structure for polyphase FIR interpolator
-    #[derive(Debug)]
-    pub struct Interp {
-        /// Interpolation factor of the interpolator
-        factor: usize,
-        /// Taps (prefer odd to increase zero coeffs)
-        taps: usize,
-        /// Number of channels
-        channels: u32,
-        /// Size of delay buffer
-        delay: usize,
-        /// List of subfilters (one for each factor)
-        filter: SmallVec<[Filter; 4]>,
-        /// List of delay buffers (one for each channel)
-        z: Box<[f32]>,
-        /// Current delay buffer index
-        zi: usize,
-    }
-
-    #[derive(Debug)]
-    struct Filter {
-        /// List of subfilter coefficients and corresponding delay indices
-        coeff: Box<[(f64, usize)]>,
-    }
-
-    impl Interp {
-        #[allow(clippy::many_single_char_names)]
-        pub fn new(taps: usize, factor: usize, channels: u32) -> Self {
-            let delay = (taps + factor - 1) / factor;
-
-            // Initialize the filter memory
-            // One subfilter per interpolation factor.
-            let mut filter = SmallVec::<[_; 4]>::new();
-
-            for _ in 0..factor {
-                filter.push(vec![]);
+        impl<F> Default for $name<F>
+        where
+            F: FrameAccumulator + Default,
+        {
+            fn default() -> Self {
+                Self::new()
             }
+        }
 
-            // One delay buffer per channel.
-            let z = vec![0.0; delay * channels as usize];
+        impl<F> $name<F>
+        where
+            F: FrameAccumulator + Default,
+        {
+            pub fn new() -> Self {
+                let mut filter: [[_; $factor]; (TAPS / $factor)] = Default::default();
+                for (j, coeff) in filter
+                    .iter_mut()
+                    .map(|x| x.iter_mut())
+                    .flatten()
+                    .enumerate()
+                {
+                    let j = j as f64;
+                    // Calculate Hanning window,
+                    let window = TAPS + 1;
+                    // Ignore one tap. (Last tap is zero anyways, and we want to hit an even multiple of 48)
+                    let window = (window - 1) as f64;
+                    let w = 0.5 * (1.0 - f64::cos(2.0 * PI * j / window));
 
-            // Calculate the filter coefficients.
-            for j in 0..taps {
-                const ALMOST_ZERO: f64 = 0.000001;
+                    // Calculate sinc and apply hanning window
+                    let m = j - window / 2.0;
+                    *coeff = if m.abs() > ALMOST_ZERO {
+                        w * f64::sin(m * PI / $factor as f64) / (m * PI / $factor as f64)
+                    } else {
+                        w
+                    } as f32;
+                }
 
-                // Calculate Hanning window
-                let w =
-                    0.5 * (1.0 - f64::cos(2.0 * f64::consts::PI * j as f64 / (taps - 1) as f64));
-
-                // Calculate sinc and apply hanning window
-                let m = j as f64 - (taps - 1) as f64 / 2.0;
-                let c = if m.abs() > ALMOST_ZERO {
-                    w * f64::sin(m * f64::consts::PI / factor as f64)
-                        / (m * f64::consts::PI / factor as f64)
-                } else {
-                    w
-                };
-
-                // Ignore any zero coeffs.
-                if c.abs() > ALMOST_ZERO {
-                    // Put the coefficient into the correct subfilter
-                    let f = j % factor;
-
-                    let f = &mut filter[f];
-                    f.push((c, j / factor));
+                Self {
+                    filter,
+                    buffer: Default::default(),
+                    buffer_pos: (TAPS / $factor) - 1,
                 }
             }
 
-            Interp {
-                factor,
-                taps,
-                channels,
-                delay,
-                filter: filter
-                    .into_iter()
-                    .map(|f| Filter {
-                        coeff: f.into_boxed_slice(),
-                    })
-                    .collect(),
-                z: z.into_boxed_slice(),
-                zi: 0,
-            }
-        }
-    }
+            pub fn interpolate(&mut self, frame: F) -> [F; $factor] {
+                // Write in Frames in reverse, to enable forward-scanning with filter
+                self.buffer_pos = (self.buffer_pos + self.buffer.len() - 1) % self.buffer.len();
+                self.buffer[self.buffer_pos] = frame;
 
-    impl super::Interpolator for Interp {
-        fn get_factor(&self) -> usize {
-            self.factor
-        }
+                let mut output: [F; $factor] = Default::default();
 
-        fn reset(&mut self) {
-            // TODO: Use slice::fill() once stabilized
-            for v in &mut *self.z {
-                *v = 0.0;
-            }
-            self.zi = 0;
-        }
+                let mut filterp = 0;
 
-        fn process(&mut self, src: &[f32], dst: &mut [f32]) {
-            assert!(src.len().checked_mul(self.factor) == Some(dst.len()));
-            assert!(self.z.len() == self.delay * self.channels as usize);
-            assert!(self.filter.len() == self.factor);
-            assert!(self.zi < self.delay);
-
-            if src.is_empty() {
-                return;
-            }
-
-            let frames = src.len() / self.channels as usize;
-            let mut zi = self.zi;
-
-            for (src, (dst, z)) in src.chunks_exact(frames).zip(
-                dst.chunks_exact_mut(frames * self.factor)
-                    .zip(self.z.chunks_exact_mut(self.delay)),
-            ) {
-                zi = self.zi;
-
-                for (src, dst) in src.iter().zip(dst.chunks_exact_mut(self.factor)) {
-                    // Add sample to delay buffer
-                    //
-                    // TODO Ringbuffer without bounds checks for z/zi
-                    //
-                    // Safety: zi is checked to be between 0 and self.delay
-                    *unsafe { z.get_unchecked_mut(zi) } = *src;
-
-                    // Apply coefficients
-                    for (filter, dst) in self.filter.iter().zip(dst.iter_mut()) {
-                        let mut acc = 0.0;
-                        for (c, index) in &*filter.coeff {
-                            let i = (zi as i32 + *index as i32) % self.delay as i32;
-
-                            // Safety: zi is checked to be between 0 and self.delay
-                            acc += *unsafe { z.get_unchecked(i as usize) } as f64 * c;
-                        }
-
-                        *dst = acc as f32;
+                for input_frame in &self.buffer[self.buffer_pos..] {
+                    let filter_coeffs = &self.filter[filterp];
+                    for (output_frame, coeff) in Iterator::zip(output.iter_mut(), filter_coeffs) {
+                        output_frame.scale_add(input_frame, *coeff);
                     }
-
-                    zi = (zi + self.delay - 1) % self.delay;
+                    filterp += 1;
                 }
-            }
-
-            self.zi = zi;
-        }
-    }
-}
-
-/// A trait to be generic over number of channels in a of frame
-///
-/// TODO: Might want to use dasp-frame instead here, but needs
-/// coordination with `Samples` trait
-trait Frame: Sized + Copy {
-    const CHANNELS: usize;
-
-    fn scale_add(&mut self, other: &Self, coeff: f32);
-    fn from_planar(slice: &[f32], stride: usize) -> Self;
-}
-
-type MonoFrame32 = [f32; 1];
-type StereoFrame32 = [f32; 2];
-type QuadFrame32 = [f32; 4];
-type SurroundFrame32 = [f32; 6];
-type Surround8Frame32 = [f32; 8];
-
-impl Frame for MonoFrame32 {
-    const CHANNELS: usize = 1;
-
-    #[inline(always)]
-    fn scale_add(&mut self, other: &Self, coeff: f32) {
-        for i in 0..Self::CHANNELS {
-            #[cfg(feature = "precision-true-peak")]
-            {
-                self[i] = other[i].mul_add(coeff, self[i]);
-            }
-            #[cfg(not(feature = "precision-true-peak"))]
-            {
-                self[i] += other[i] * coeff;
-            }
-        }
-    }
-
-    #[inline(always)]
-    fn from_planar(slice: &[f32], _stride: usize) -> Self {
-        [slice[0]]
-    }
-}
-
-impl Frame for StereoFrame32 {
-    const CHANNELS: usize = 2;
-
-    #[inline(always)]
-    fn scale_add(&mut self, other: &Self, coeff: f32) {
-        for i in 0..Self::CHANNELS {
-            #[cfg(feature = "precision-true-peak")]
-            {
-                self[i] = other[i].mul_add(coeff, self[i]);
-            }
-            #[cfg(not(feature = "precision-true-peak"))]
-            {
-                self[i] += other[i] * coeff;
-            }
-        }
-    }
-
-    #[inline(always)]
-    fn from_planar(slice: &[f32], stride: usize) -> Self {
-        [slice[0], slice[stride]]
-    }
-}
-
-impl Frame for QuadFrame32 {
-    const CHANNELS: usize = 4;
-
-    #[inline(always)]
-    fn scale_add(&mut self, other: &Self, coeff: f32) {
-        for i in 0..Self::CHANNELS {
-            #[cfg(feature = "precision-true-peak")]
-            {
-                self[i] = other[i].mul_add(coeff, self[i]);
-            }
-            #[cfg(not(feature = "precision-true-peak"))]
-            {
-                self[i] += other[i] * coeff;
-            }
-        }
-    }
-
-    #[inline(always)]
-    fn from_planar(slice: &[f32], stride: usize) -> Self {
-        [
-            slice[0],
-            slice[stride],
-            slice[2 * stride],
-            slice[3 * stride],
-        ]
-    }
-}
-
-impl Frame for SurroundFrame32 {
-    const CHANNELS: usize = 6;
-
-    #[inline(always)]
-    fn scale_add(&mut self, other: &Self, coeff: f32) {
-        for i in 0..Self::CHANNELS {
-            #[cfg(feature = "precision-true-peak")]
-            {
-                self[i] = other[i].mul_add(coeff, self[i]);
-            }
-            #[cfg(not(feature = "precision-true-peak"))]
-            {
-                self[i] += other[i] * coeff;
-            }
-        }
-    }
-
-    #[inline(always)]
-    fn from_planar(slice: &[f32], stride: usize) -> Self {
-        [
-            slice[0],
-            slice[stride],
-            slice[2 * stride],
-            slice[3 * stride],
-            slice[4 * stride],
-            slice[5 * stride],
-        ]
-    }
-}
-
-impl Frame for Surround8Frame32 {
-    const CHANNELS: usize = 8;
-
-    #[inline(always)]
-    fn scale_add(&mut self, other: &Self, coeff: f32) {
-        for i in 0..Self::CHANNELS {
-            #[cfg(feature = "precision-true-peak")]
-            {
-                self[i] = other[i].mul_add(coeff, self[i]);
-            }
-            #[cfg(not(feature = "precision-true-peak"))]
-            {
-                self[i] += other[i] * coeff;
-            }
-        }
-    }
-
-    #[inline(always)]
-    fn from_planar(slice: &[f32], stride: usize) -> Self {
-        [
-            slice[0],
-            slice[stride],
-            slice[2 * stride],
-            slice[3 * stride],
-            slice[4 * stride],
-            slice[5 * stride],
-            slice[6 * stride],
-            slice[7 * stride],
-        ]
-    }
-}
-
-mod specialized {
-    use super::Frame;
-    use std::f64::consts::PI;
-
-    const ALMOST_ZERO: f64 = 0.000001;
-    const TAPS: usize = 48;
-
-    const FACTOR4: usize = 4;
-    const FACTOR4_INPUT_LENGTH: usize = TAPS / FACTOR4;
-    const FACTOR2: usize = 2;
-    const FACTOR2_INPUT_LENGTH: usize = TAPS / FACTOR2;
-
-    #[derive(Debug)]
-    pub(super) struct Interp4F<F: Frame> {
-        filter: [[f32; FACTOR4]; FACTOR4_INPUT_LENGTH],
-        buffer: [F; FACTOR4_INPUT_LENGTH],
-        buffer_pos: usize,
-    }
-
-    impl<F> Interp4F<F>
-    where
-        F: Frame + Default,
-    {
-        pub(super) fn new() -> Self {
-            let mut filter: [[_; FACTOR4]; FACTOR4_INPUT_LENGTH] = Default::default();
-            for (j, coeff) in filter
-                .iter_mut()
-                .map(|x| x.iter_mut())
-                .flatten()
-                .enumerate()
-            {
-                let j = j as f64;
-                // Calculate Hanning window, with one tap ignored. (Last tap is zero anyways, and we want to hit
-                // an even multiple of 48)
-                let window = (TAPS - 1 + 1) as f64;
-                let w = 0.5 * (1.0 - f64::cos(2.0 * PI * j / window));
-
-                // Calculate sinc and apply hanning window
-                let m = j - window / 2.0;
-                *coeff = if m.abs() > ALMOST_ZERO {
-                    w * f64::sin(m * PI / FACTOR4 as f64) / (m * PI / FACTOR4 as f64)
-                } else {
-                    w
-                } as f32;
-            }
-
-            Self {
-                filter,
-                buffer: Default::default(),
-                buffer_pos: (FACTOR4_INPUT_LENGTH) - 1,
-            }
-        }
-
-        pub(super) fn push(&mut self, frame: &F) -> [F; FACTOR4] {
-            // Write in Frames in reverse, to enable forward-scanning with filter
-            self.buffer_pos = (self.buffer_pos + self.buffer.len() - 1) % self.buffer.len();
-            self.buffer[self.buffer_pos] = *frame;
-
-            let mut output: [F; FACTOR4] = Default::default();
-
-            let mut filterp = 0;
-
-            for input_frame in &self.buffer[self.buffer_pos..] {
-                let filter_coeffs = &self.filter[filterp];
-                for (output_frame, coeff) in Iterator::zip(output.iter_mut(), filter_coeffs) {
-                    output_frame.scale_add(input_frame, *coeff);
-                }
-                filterp += 1;
-            }
-            for input_frame in &self.buffer[..self.buffer_pos] {
-                let filter_coeffs = &self.filter[filterp];
-                for (output_frame, coeff) in Iterator::zip(output.iter_mut(), filter_coeffs) {
-                    output_frame.scale_add(input_frame, *coeff);
-                }
-                filterp += 1;
-            }
-
-            output
-        }
-    }
-
-    impl<F> super::Interpolator for Interp4F<F>
-    where
-        F: Frame + std::fmt::Debug + Default + AsRef<[f32]>,
-    {
-        fn process(&mut self, src: &[f32], dst: &mut [f32]) {
-            assert_eq!(0, src.len() % F::CHANNELS);
-            assert_eq!(src.len() * FACTOR4, dst.len());
-            let frames = src.len() / F::CHANNELS;
-
-            for i in 0..frames {
-                let res = self.push(&F::from_planar(&src[i..], frames));
-                for c in 0..F::CHANNELS {
-                    for (f, frame) in res.iter().enumerate() {
-                        dst[c * frames * FACTOR4 + i * FACTOR4 + f] = frame.as_ref()[c];
+                for input_frame in &self.buffer[..self.buffer_pos] {
+                    let filter_coeffs = &self.filter[filterp];
+                    for (output_frame, coeff) in Iterator::zip(output.iter_mut(), filter_coeffs) {
+                        output_frame.scale_add(input_frame, *coeff);
                     }
+                    filterp += 1;
                 }
-            }
-        }
 
-        fn reset(&mut self) {
-            self.buffer = Default::default();
-        }
-
-        fn get_factor(&self) -> usize {
-            4
-        }
-    }
-
-    #[derive(Debug)]
-    pub(super) struct Interp2F<F: Frame> {
-        filter: [[f32; FACTOR2]; FACTOR2_INPUT_LENGTH],
-        buffer: [F; FACTOR2_INPUT_LENGTH],
-        buffer_pos: usize,
-    }
-
-    impl<F> Interp2F<F>
-    where
-        F: Frame + Default,
-    {
-        pub(super) fn new() -> Self {
-            let mut filter: [[_; FACTOR2]; FACTOR2_INPUT_LENGTH] = Default::default();
-            for (j, coeff) in filter
-                .iter_mut()
-                .map(|x| x.iter_mut())
-                .flatten()
-                .enumerate()
-            {
-                let j = j as f64;
-                // Calculate Hanning window, with one tap ignored. (Last tap is zero anyways, and we want to hit
-                // an even multiple of 48)
-                let window = (TAPS - 1 + 1) as f64;
-                let w = 0.5 * (1.0 - f64::cos(2.0 * PI * j / window));
-
-                // Calculate sinc and apply hanning window
-                let m = j - window / 2.0;
-                *coeff = if m.abs() > ALMOST_ZERO {
-                    w * f64::sin(m * PI / FACTOR2 as f64) / (m * PI / FACTOR2 as f64)
-                } else {
-                    w
-                } as f32;
+                output
             }
 
-            Self {
-                filter,
-                buffer: Default::default(),
-                buffer_pos: (FACTOR2_INPUT_LENGTH) - 1,
+            pub fn reset(&mut self) {
+                self.buffer = Default::default();
             }
         }
-
-        pub(super) fn push(&mut self, frame: &F) -> [F; FACTOR2] {
-            // Write in Frames in reverse, to enable forward-scanning with filter
-            self.buffer_pos = (self.buffer_pos + self.buffer.len() - 1) % self.buffer.len();
-            self.buffer[self.buffer_pos] = *frame;
-
-            let mut output: [F; FACTOR2] = Default::default();
-
-            let mut filterp = 0;
-
-            for input_frame in &self.buffer[self.buffer_pos..] {
-                let filter_coeffs = &self.filter[filterp];
-                for (output_frame, coeff) in Iterator::zip(output.iter_mut(), filter_coeffs) {
-                    output_frame.scale_add(input_frame, *coeff);
-                }
-                filterp += 1;
-            }
-            for input_frame in &self.buffer[..self.buffer_pos] {
-                let filter_coeffs = &self.filter[filterp];
-                for (output_frame, coeff) in Iterator::zip(output.iter_mut(), filter_coeffs) {
-                    output_frame.scale_add(input_frame, *coeff);
-                }
-                filterp += 1;
-            }
-
-            output
-        }
-    }
-
-    impl<F> super::Interpolator for Interp2F<F>
-    where
-        F: Frame + std::fmt::Debug + Default + AsRef<[f32]>,
-    {
-        fn process(&mut self, src: &[f32], dst: &mut [f32]) {
-            assert_eq!(0, src.len() % F::CHANNELS);
-            assert_eq!(src.len() * FACTOR2, dst.len());
-            let frames = src.len() / F::CHANNELS;
-
-            for i in 0..frames {
-                let res = self.push(&F::from_planar(&src[i..], frames));
-                for c in 0..F::CHANNELS {
-                    for (f, frame) in res.iter().enumerate() {
-                        dst[c * frames * FACTOR2 + i * FACTOR2 + f] = frame.as_ref()[c];
-                    }
-                }
-            }
-        }
-
-        fn reset(&mut self) {
-            self.buffer = Default::default();
-        }
-
-        fn get_factor(&self) -> usize {
-            2
-        }
-    }
+    };
 }
+
+interp_impl!(Interp2F, 2);
+interp_impl!(Interp4F, 4);
 
 #[cfg(feature = "c-tests")]
 use std::os::raw::c_void;
@@ -584,27 +130,6 @@ extern "C" {
     pub fn interp_destroy_c(interp: *mut c_void);
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn internally_consistent() {
-        let factor = 4;
-        let src = (0..1024)
-            .map(|i| (i as f32 - 512.) / 512.)
-            .collect::<Vec<_>>();
-        let mut dst_stereo = vec![0.; src.len() * factor];
-        let mut dst_dual_mono = vec![0.; src.len() * factor];
-
-        Interp::new(49, factor, 2).process(&src, &mut dst_stereo);
-        Interp::new(49, factor, 1).process(&src[..512], &mut dst_dual_mono[..512 * factor]);
-        Interp::new(49, factor, 1).process(&src[512..], &mut dst_dual_mono[512 * factor..]);
-
-        assert_eq!(dst_stereo, dst_dual_mono);
-    }
-}
-
 #[cfg(feature = "c-tests")]
 #[cfg(test)]
 mod c_tests {
@@ -612,6 +137,55 @@ mod c_tests {
     use crate::tests::Signal;
     use float_eq::assert_float_eq;
     use quickcheck_macros::quickcheck;
+
+    fn process_rust(data_in: &[f32], data_out: &mut [f32], factor: usize, channels: usize) {
+        macro_rules! process_specialized {
+            ( $interp:ident, $channels:expr ) => {{
+                let mut interp = $interp::new();
+                let (_, data_in, _) = unsafe { data_in.align_to::<[f32; $channels]>() };
+                let (_, data_out, _) = unsafe { data_out.align_to_mut::<[f32; $channels]>() };
+                for (input_frame, output_frames) in
+                    Iterator::zip(data_in.into_iter(), data_out.chunks_exact_mut(factor))
+                {
+                    output_frames.copy_from_slice(&interp.interpolate(*input_frame));
+                }
+            }};
+        }
+
+        macro_rules! process_generic {
+            ( $interp:ident, $channels:expr ) => {{
+                let mut interp = vec![$interp::<[f32; 1]>::new(); $channels];
+                let frames = data_in.len() / channels;
+                for frame in 0..frames {
+                    for channel in 0..$channels {
+                        let in_sample = data_in[(frame * $channels) + channel];
+                        for (o, [output_sample]) in
+                            interp[channel].interpolate([in_sample]).iter().enumerate()
+                        {
+                            let output_frame = frame * factor + o;
+                            data_out[(output_frame * $channels) + channel] = *output_sample;
+                        }
+                    }
+                }
+            }};
+        }
+
+        match (factor, channels) {
+            (2, 1) => process_specialized!(Interp2F, 1),
+            (2, 2) => process_specialized!(Interp2F, 2),
+            (2, 4) => process_specialized!(Interp2F, 4),
+            (2, 6) => process_specialized!(Interp2F, 6),
+            (2, 8) => process_specialized!(Interp2F, 8),
+            (4, 1) => process_specialized!(Interp4F, 1),
+            (4, 2) => process_specialized!(Interp4F, 2),
+            (4, 4) => process_specialized!(Interp4F, 4),
+            (4, 6) => process_specialized!(Interp4F, 6),
+            (4, 8) => process_specialized!(Interp4F, 8),
+            (2, c) => process_generic!(Interp2F, c),
+            (4, c) => process_generic!(Interp4F, c),
+            _ => unimplemented!(),
+        }
+    }
 
     #[quickcheck]
     fn compare_c_impl(signal: Signal<f32>) -> quickcheck::TestResult {
@@ -627,26 +201,12 @@ mod c_tests {
         let mut data_out = vec![0.0f32; signal.data.len() * factor];
         let mut data_out_c = vec![0.0f32; signal.data.len() * factor];
 
-        {
-            // Need to deinterleave the input and interleave the output
-            let mut data_in_tmp = vec![0.0f32; signal.data.len()];
-            let mut data_out_tmp = vec![0.0f32; signal.data.len() * factor];
-
-            for (c, out) in data_in_tmp.chunks_exact_mut(frames).enumerate() {
-                for (s, out) in out.iter_mut().enumerate() {
-                    *out = signal.data[signal.channels as usize * s + c];
-                }
-            }
-
-            let mut interp = Interp::new(49, factor, signal.channels);
-            interp.process(&data_in_tmp, &mut data_out_tmp);
-
-            for (c, i) in data_out_tmp.chunks_exact(frames * factor).enumerate() {
-                for (s, i) in i.iter().enumerate() {
-                    data_out[signal.channels as usize * s + c] = *i;
-                }
-            }
-        }
+        process_rust(
+            &signal.data,
+            &mut data_out,
+            factor,
+            signal.channels as usize,
+        );
 
         unsafe {
             let interp = interp_create_c(49, factor as u32, signal.channels);

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -25,13 +25,70 @@ use std::f64::consts::PI;
 const ALMOST_ZERO: f64 = 0.000001;
 const TAPS: usize = 48;
 
+// Workaround for missing const-generics
+trait ArrayBuf<Item>: std::borrow::BorrowMut<[Item]> {
+    const SIZE: usize;
+}
+
+impl<Item> ArrayBuf<Item> for [Item; 24] {
+    const SIZE: usize = 24;
+}
+
+impl<Item> ArrayBuf<Item> for [Item; 12] {
+    const SIZE: usize = 12;
+}
+
+/// A circular buffer offering fixed-length continous views into data
+/// This is enabled by writing data twice, also to a "shadow"-buffer following the primary buffer,
+/// The tradeoff is writing all data twice, the gain is giving the compiler continuous view with
+/// predictable length into the data, unlocking some more optimizations
+#[derive(Clone, Debug)]
+struct RollingBuffer<A, T> {
+    buf: [T; TAPS],
+    position: usize,
+    _phantom: std::marker::PhantomData<A>,
+}
+
+impl<A: ArrayBuf<T>, T: Default + Copy> RollingBuffer<A, T> {
+    fn new() -> Self {
+        assert!(A::SIZE * 2 <= TAPS);
+
+        let buf: [T; TAPS] = [Default::default(); TAPS];
+
+        Self {
+            buf,
+            position: A::SIZE,
+            _phantom: Default::default(),
+        }
+    }
+
+    #[inline(always)]
+    fn push_front(&mut self, v: T) {
+        if self.position == 0 {
+            self.position = A::SIZE - 1;
+        } else {
+            self.position -= 1;
+        }
+        unsafe {
+            *self.buf.get_unchecked_mut(self.position) = v;
+            *self.buf.get_unchecked_mut(self.position + A::SIZE) = v;
+        }
+    }
+}
+
+impl<A, T> AsRef<A> for RollingBuffer<A, T> {
+    #[inline(always)]
+    fn as_ref(&self) -> &A {
+        unsafe { &*(self.buf.get_unchecked(self.position) as *const T as *const A) }
+    }
+}
+
 macro_rules! interp_impl {
     ( $name:ident, $factor:expr ) => {
         #[derive(Debug, Clone)]
         pub struct $name<F: FrameAccumulator> {
             filter: [[f32; $factor]; (TAPS / $factor)],
-            buffer: [F; (TAPS / $factor)],
-            buffer_pos: usize,
+            buffer: RollingBuffer<[F; TAPS / $factor], F>,
         }
 
         impl<F> Default for $name<F>
@@ -73,40 +130,29 @@ macro_rules! interp_impl {
 
                 Self {
                     filter,
-                    buffer: Default::default(),
-                    buffer_pos: (TAPS / $factor) - 1,
+                    buffer: RollingBuffer::new(),
                 }
             }
 
             pub fn interpolate(&mut self, frame: F) -> [F; $factor] {
                 // Write in Frames in reverse, to enable forward-scanning with filter
-                self.buffer_pos = (self.buffer_pos + self.buffer.len() - 1) % self.buffer.len();
-                self.buffer[self.buffer_pos] = frame;
+                self.buffer.push_front(frame);
 
                 let mut output: [F; $factor] = Default::default();
 
-                let mut filterp = 0;
+                let buf = self.buffer.as_ref();
 
-                for input_frame in &self.buffer[self.buffer_pos..] {
-                    let filter_coeffs = &self.filter[filterp];
+                for (filter_coeffs, input_frame) in Iterator::zip(self.filter.iter(), buf) {
                     for (output_frame, coeff) in Iterator::zip(output.iter_mut(), filter_coeffs) {
                         output_frame.scale_add(input_frame, *coeff);
                     }
-                    filterp += 1;
-                }
-                for input_frame in &self.buffer[..self.buffer_pos] {
-                    let filter_coeffs = &self.filter[filterp];
-                    for (output_frame, coeff) in Iterator::zip(output.iter_mut(), filter_coeffs) {
-                        output_frame.scale_add(input_frame, *coeff);
-                    }
-                    filterp += 1;
                 }
 
                 output
             }
 
             pub fn reset(&mut self) {
-                self.buffer = Default::default();
+                self.buffer = RollingBuffer::new();
             }
         }
     };

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -664,7 +664,7 @@ mod c_tests {
                 *r,
                 *c,
                 // For a performance-boost, filter is defined as f32, causing slightly lower precision
-                abs <= 0.000002,
+                abs <= 0.000004,
                 "Rust and C implementation differ at sample {}",
                 i
             );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,9 +66,9 @@ pub mod utils;
 pub(crate) mod utils;
 
 #[cfg(feature = "internal-tests")]
-pub use utils::{energy_to_loudness, AsF32, AsF64, Interleaved, Planar, Samples};
+pub use utils::{energy_to_loudness, Interleaved, Planar, Samples};
 #[cfg(not(feature = "internal-tests"))]
-pub(crate) use utils::{energy_to_loudness, AsF32, AsF64, Interleaved, Planar, Samples};
+pub(crate) use utils::{energy_to_loudness, Interleaved, Planar, Samples};
 
 #[cfg(test)]
 pub mod tests {

--- a/src/true_peak.rs
+++ b/src/true_peak.rs
@@ -203,7 +203,7 @@ mod tests {
                 *r,
                 *c,
                 // For a performance-boost, interpolation-filter is defined as f32, causing lower precision
-                abs <= 0.000002,
+                abs <= 0.000004,
                 "Rust and C implementation differ at channel {}",
                 i,
             );
@@ -250,7 +250,7 @@ mod tests {
                 *r,
                 *c,
                 // For a performance-boost, interpolation-filter is defined as f32, causing lower precision
-                abs <= 0.000002,
+                abs <= 0.000004,
                 "Rust and C implementation differ at channel {}",
                 i
             );
@@ -297,7 +297,7 @@ mod tests {
                 *r,
                 *c,
                 // For a performance-boost, interpolation-filter is defined as f32, causing lower precision
-                abs <= 0.000002,
+                abs <= 0.000004,
                 "Rust and C implementation differ at channel {}",
                 i
             );
@@ -344,7 +344,7 @@ mod tests {
                 *r,
                 *c,
                 // For a performance-boost, interpolation-filter is defined as f32, causing lower precision
-                abs <= 0.000002,
+                abs <= 0.000004,
                 "Rust and C implementation differ at channel {}",
                 i
             );

--- a/src/true_peak.rs
+++ b/src/true_peak.rs
@@ -21,7 +21,7 @@
 
 use crate::interp::Interp;
 
-use dasp_sample::{Sample, ToSample};
+use crate::utils::Sample;
 
 /// True peak measurement.
 #[derive(Debug)]
@@ -68,7 +68,7 @@ impl TruePeak {
         self.interp.reset();
     }
 
-    pub fn check_true_peak<'a, T: Sample + ToSample<f32> + 'a, S: crate::Samples<'a, T>>(
+    pub fn check_true_peak<'a, T: Sample + 'a, S: crate::Samples<'a, T>>(
         &mut self,
         src: &S,
         peaks: &mut [f64],

--- a/src/true_peak.rs
+++ b/src/true_peak.rs
@@ -21,6 +21,8 @@
 
 use crate::interp::Interp;
 
+use dasp_sample::{Sample, ToSample};
+
 /// True peak measurement.
 #[derive(Debug)]
 pub struct TruePeak {
@@ -66,7 +68,7 @@ impl TruePeak {
         self.interp.reset();
     }
 
-    pub fn check_true_peak<'a, T: crate::AsF32 + 'a, S: crate::Samples<'a, T>>(
+    pub fn check_true_peak<'a, T: Sample + ToSample<f32> + 'a, S: crate::Samples<'a, T>>(
         &mut self,
         src: &S,
         peaks: &mut [f64],
@@ -98,7 +100,7 @@ impl TruePeak {
             assert!(c < src.channels());
 
             src.foreach_sample_zipped(c, dest.iter_mut(), |src, dest| {
-                *dest = src.as_f32_scaled();
+                *dest = src.to_sample();
             });
         }
 


### PR DESCRIPTION
This is the second of the two TruePeak analysis optimizations. The key optimization here, is avoiding extra memory-copying by not keeping input and output from the upsamling. Every new input-frame is fed immediately to the interpolator, generating 2 or 4 new frames which are immediately checked for new max before being discarded.

The net gain according to my benchmark:

> true_peak: 48kHz 2ch f32/Rust
>   /Interleaved: 545.50 -> 395.99 (-27.4%) 
>   /Planar:      556.07 -> 424.97 (-23.6%) 
> 
> true_peak: 48kHz 2ch i16/Rust
>   /Interleaved: 550.95 -> 436.63 (-20.7%) 
>   /Planar:      579.58 -> 476.53 (-17.8%) 

As a nice bonus, it also cleans up a lot of code from the previous step of optimization, causing a significant net reduction of code.

>  8 files changed, 462 insertions(+), 363 deletions(-)