### PR TITLE
Bugfix: True-peak broken when first samples are high-valued

### DIFF
--- a/benches/filter.rs
+++ b/benches/filter.rs
@@ -83,7 +83,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             group.bench_function("Rust/Interleaved", |b| {
                 b.iter(|| {
                     f.process(
-                        black_box(&ebur128::Interleaved::new(&*data, 2).unwrap()),
+                        black_box(ebur128::Interleaved::new(&*data, 2).unwrap()),
                         black_box(&mut data_out),
                         black_box(0),
                         black_box(&channel_map),
@@ -95,7 +95,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             group.bench_function("Rust/Planar", |b| {
                 b.iter(|| {
                     f.process(
-                        black_box(&ebur128::Planar::new(&[fst, snd]).unwrap()),
+                        black_box(ebur128::Planar::new(&[fst, snd]).unwrap()),
                         black_box(&mut data_out),
                         black_box(0),
                         black_box(&channel_map),
@@ -147,7 +147,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             group.bench_function("Rust/Interleaved", |b| {
                 b.iter(|| {
                     f.process(
-                        black_box(&ebur128::Interleaved::new(&*data, 2).unwrap()),
+                        black_box(ebur128::Interleaved::new(&*data, 2).unwrap()),
                         black_box(&mut data_out),
                         black_box(0),
                         black_box(&channel_map),
@@ -159,7 +159,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             group.bench_function("Rust/Planar", |b| {
                 b.iter(|| {
                     f.process(
-                        black_box(&ebur128::Planar::new(&[fst, snd]).unwrap()),
+                        black_box(ebur128::Planar::new(&[fst, snd]).unwrap()),
                         black_box(&mut data_out),
                         black_box(0),
                         black_box(&channel_map),
@@ -211,7 +211,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             group.bench_function("Rust/Interleaved", |b| {
                 b.iter(|| {
                     f.process(
-                        black_box(&ebur128::Interleaved::new(&*data, 2).unwrap()),
+                        black_box(ebur128::Interleaved::new(&*data, 2).unwrap()),
                         black_box(&mut data_out),
                         black_box(0),
                         black_box(&channel_map),
@@ -223,7 +223,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             group.bench_function("Rust/Planar", |b| {
                 b.iter(|| {
                     f.process(
-                        black_box(&ebur128::Planar::new(&[fst, snd]).unwrap()),
+                        black_box(ebur128::Planar::new(&[fst, snd]).unwrap()),
                         black_box(&mut data_out),
                         black_box(0),
                         black_box(&channel_map),
@@ -275,7 +275,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             group.bench_function("Rust/Interleaved", |b| {
                 b.iter(|| {
                     f.process(
-                        black_box(&ebur128::Interleaved::new(&*data, 2).unwrap()),
+                        black_box(ebur128::Interleaved::new(&*data, 2).unwrap()),
                         black_box(&mut data_out),
                         black_box(0),
                         black_box(&channel_map),
@@ -287,7 +287,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             group.bench_function("Rust/Planar", |b| {
                 b.iter(|| {
                     f.process(
-                        black_box(&ebur128::Planar::new(&[fst, snd]).unwrap()),
+                        black_box(ebur128::Planar::new(&[fst, snd]).unwrap()),
                         black_box(&mut data_out),
                         black_box(0),
                         black_box(&channel_map),

--- a/benches/true_peak.rs
+++ b/benches/true_peak.rs
@@ -47,7 +47,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("Rust/Interleaved", |b| {
             b.iter(|| {
                 tp.check_true_peak(
-                    black_box(&ebur128::Interleaved::new(&data, 2).unwrap()),
+                    black_box(ebur128::Interleaved::new(&data, 2).unwrap()),
                     black_box(&mut peaks),
                 );
             })
@@ -57,7 +57,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("Rust/Planar", |b| {
             b.iter(|| {
                 tp.check_true_peak(
-                    black_box(&ebur128::Planar::new(&[fst, snd]).unwrap()),
+                    black_box(ebur128::Planar::new(&[fst, snd]).unwrap()),
                     black_box(&mut peaks),
                 );
             })
@@ -108,7 +108,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("Rust/Interleaved", |b| {
             b.iter(|| {
                 tp.check_true_peak(
-                    black_box(&ebur128::Interleaved::new(&data, 2).unwrap()),
+                    black_box(ebur128::Interleaved::new(&data, 2).unwrap()),
                     black_box(&mut peaks),
                 );
             })
@@ -118,7 +118,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("Rust/Planar", |b| {
             b.iter(|| {
                 tp.check_true_peak(
-                    black_box(&ebur128::Planar::new(&[fst, snd]).unwrap()),
+                    black_box(ebur128::Planar::new(&[fst, snd]).unwrap()),
                     black_box(&mut peaks),
                 );
             })
@@ -169,7 +169,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("Rust/Interleaved", |b| {
             b.iter(|| {
                 tp.check_true_peak(
-                    black_box(&ebur128::Interleaved::new(&data, 2).unwrap()),
+                    black_box(ebur128::Interleaved::new(&data, 2).unwrap()),
                     black_box(&mut peaks),
                 );
             })
@@ -179,7 +179,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("Rust/Planar", |b| {
             b.iter(|| {
                 tp.check_true_peak(
-                    black_box(&ebur128::Planar::new(&[fst, snd]).unwrap()),
+                    black_box(ebur128::Planar::new(&[fst, snd]).unwrap()),
                     black_box(&mut peaks),
                 );
             })
@@ -230,7 +230,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("Rust/Interleaved", |b| {
             b.iter(|| {
                 tp.check_true_peak(
-                    black_box(&ebur128::Interleaved::new(&data, 2).unwrap()),
+                    black_box(ebur128::Interleaved::new(&data, 2).unwrap()),
                     black_box(&mut peaks),
                 );
             })
@@ -240,7 +240,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         group.bench_function("Rust/Planar", |b| {
             b.iter(|| {
                 tp.check_true_peak(
-                    black_box(&ebur128::Planar::new(&[fst, snd]).unwrap()),
+                    black_box(ebur128::Planar::new(&[fst, snd]).unwrap()),
                     black_box(&mut peaks),
                 );
             })

--- a/src/ebur128.rs
+++ b/src/ebur128.rs
@@ -594,7 +594,7 @@ impl EbuR128 {
                 let (current, next) = src.split_at(self.needed_frames);
 
                 self.filter.process(
-                    &current,
+                    current,
                     &mut *self.audio_data,
                     self.audio_data_index,
                     &self.channel_map,
@@ -632,7 +632,7 @@ impl EbuR128 {
                 let (current, next) = src.split_at(num_frames);
 
                 self.filter.process(
-                    &current,
+                    current,
                     &mut *self.audio_data,
                     self.audio_data_index,
                     &self.channel_map,

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -174,7 +174,7 @@ impl Filter {
 
     pub fn process<'a, T: Sample + 'a, S: crate::Samples<'a, T>>(
         &mut self,
-        src: &S,
+        src: S,
         dest: &mut [f64],
         dest_index: usize,
         channel_map: &[crate::ebur128::Channel],
@@ -205,11 +205,6 @@ impl Filter {
                         *sample_peak = max;
                     }
                 }
-            }
-
-            if let Some(ref mut tp) = self.tp {
-                assert!(self.true_peak.len() == self.channels as usize);
-                tp.check_true_peak(src, &mut *self.true_peak);
             }
 
             let dest_stride = dest.len() / self.channels as usize;
@@ -257,6 +252,11 @@ impl Filter {
                         }
                     }
                 }
+            }
+
+            if let Some(ref mut tp) = self.tp {
+                assert!(self.true_peak.len() == self.channels as usize);
+                tp.check_true_peak(src, &mut *self.true_peak);
             }
         });
     }
@@ -517,7 +517,7 @@ mod tests {
             let mut data_out_tmp = vec![0.0f64; frames * signal.channels as usize];
 
             f.process(
-                &crate::Interleaved::new(
+                crate::Interleaved::new(
                     &signal.data[..(frames * signal.channels as usize)],
                     signal.channels as usize,
                 )
@@ -605,7 +605,7 @@ mod tests {
             let mut data_out_tmp = vec![0.0f64; frames * signal.channels as usize];
 
             f.process(
-                &crate::Interleaved::new(
+                crate::Interleaved::new(
                     &signal.data[..(frames * signal.channels as usize)],
                     signal.channels as usize,
                 )
@@ -693,7 +693,7 @@ mod tests {
             let mut data_out_tmp = vec![0.0f64; frames * signal.channels as usize];
 
             f.process(
-                &crate::Interleaved::new(
+                crate::Interleaved::new(
                     &signal.data[..(frames * signal.channels as usize)],
                     signal.channels as usize,
                 )
@@ -781,7 +781,7 @@ mod tests {
             let mut data_out_tmp = vec![0.0f64; frames * signal.channels as usize];
 
             f.process(
-                &crate::Interleaved::new(
+                crate::Interleaved::new(
                     &signal.data[..(frames * signal.channels as usize)],
                     signal.channels as usize,
                 )

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -154,6 +154,11 @@ macro_rules! interp_impl {
             pub fn reset(&mut self) {
                 self.buffer = RollingBuffer::new();
             }
+
+            #[inline(always)]
+            pub fn filter_length(&self) -> usize {
+                TAPS / $factor
+            }
         }
     };
 }

--- a/src/true_peak.rs
+++ b/src/true_peak.rs
@@ -73,7 +73,7 @@ impl UpsamplingScanner {
 
     pub fn check_true_peak<'a, T: Sample + 'a, S: crate::Samples<'a, T>>(
         &mut self,
-        src: &S,
+        src: S,
         peaks: &mut [f64],
     ) {
         macro_rules! tp_specialized_impl {
@@ -164,7 +164,7 @@ impl TruePeak {
 
     pub fn check_true_peak<'a, T: Sample + 'a, S: crate::Samples<'a, T>>(
         &mut self,
-        src: &S,
+        src: S,
         peaks: &mut [f64],
     ) {
         self.interp.check_true_peak(src, peaks)
@@ -224,7 +224,7 @@ mod tests {
         {
             let mut tp = TruePeak::new(signal.rate, signal.channels).unwrap();
             tp.check_true_peak(
-                &crate::Interleaved::new(
+                crate::Interleaved::new(
                     &signal.data[0..(len * signal.channels as usize)],
                     signal.channels as usize,
                 )
@@ -271,7 +271,7 @@ mod tests {
         {
             let mut tp = TruePeak::new(signal.rate, signal.channels).unwrap();
             tp.check_true_peak(
-                &crate::Interleaved::new(
+                crate::Interleaved::new(
                     &signal.data[0..(len * signal.channels as usize)],
                     signal.channels as usize,
                 )
@@ -318,7 +318,7 @@ mod tests {
         {
             let mut tp = TruePeak::new(signal.rate, signal.channels).unwrap();
             tp.check_true_peak(
-                &crate::Interleaved::new(
+                crate::Interleaved::new(
                     &signal.data[0..(len * signal.channels as usize)],
                     signal.channels as usize,
                 )
@@ -365,7 +365,7 @@ mod tests {
         {
             let mut tp = TruePeak::new(signal.rate, signal.channels).unwrap();
             tp.check_true_peak(
-                &crate::Interleaved::new(
+                crate::Interleaved::new(
                     &signal.data[0..(len * signal.channels as usize)],
                     signal.channels as usize,
                 )


### PR DESCRIPTION
When the first samples are high-valued (a cosine-curve is a perfect
example), the true-peak smoothing filter will incorporate some noise for
the first samples. The solution is to not emit samples before the filter is
properly saturated.