### PR TITLE
Update to cargo-c 0.9.0

### DIFF
--- a/.github/workflows/ebur128.yml
+++ b/.github/workflows/ebur128.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Install cargo-c
       env:
         LINK: https://github.com/lu-zero/cargo-c/releases/download
-        CARGO_C_VERSION: 0.6.13
+        CARGO_C_VERSION: 0.9.1
       run: |
         curl -L "$LINK/v$CARGO_C_VERSION/cargo-c-linux.tar.gz" |
         tar xz -C $HOME/.cargo/bin

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ precision-true-peak = []
 name = "ebur128"
 
 [package.metadata.capi]
-min_version = "0.6.12"
+min_version = "0.9.1"
 
 [package.metadata.capi.header]
 name = "ebur128.h"


### PR DESCRIPTION
It seems like the pre-generated header file is not installed anymore. CC @lu-zero

```toml
[package.metadata.capi]
min_version = "0.9.0"

[package.metadata.capi.header]
name = "ebur128.h"
subdirectory = false
generation = false

[package.metadata.capi.pkg_config]
name = "libebur128"
description = "EBU R 128 standard for loudness normalisation"
version = "1.2.6"

[package.metadata.capi.library]
name = "ebur128"
version = "1.2.6"
```