### PR TITLE
interp:Use new const-generics to simplify code

### DIFF
--- a/benches/interp.rs
+++ b/benches/interp.rs
@@ -31,7 +31,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     }
     group.bench_function("Rust", |b| {
         b.iter(|| {
-            let _interp = interp::Interp2F::<[f32; 4]>::new();
+            let _interp = interp::InterpF::<24, 2, [f32; 4]>::new();
         })
     });
 
@@ -54,7 +54,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         interp::interp_destroy_c(interp);
     }
     {
-        let mut interp = interp::Interp2F::new();
+        let mut interp = interp::InterpF::<24, 2, _>::new();
         let (_, data, _) = unsafe { data.align_to::<[f32; 2]>() };
         let (_, data_out, _) = unsafe { data_out.align_to_mut::<[f32; 2]>() };
         group.bench_function("Rust", |b| {
@@ -88,7 +88,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         interp::interp_destroy_c(interp);
     }
     {
-        let mut interp = interp::Interp4F::new();
+        let mut interp = interp::InterpF::<12, 4, _>::new();
         let (_, data, _) = unsafe { data.align_to::<[f32; 2]>() };
         let (_, data_out, _) = unsafe { data_out.align_to_mut::<[f32; 2]>() };
         group.bench_function("Rust", |b| {

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -25,141 +25,117 @@ use std::f64::consts::PI;
 const ALMOST_ZERO: f64 = 0.000001;
 const TAPS: usize = 48;
 
-// Workaround for missing const-generics
-trait ArrayBuf<Item>: std::borrow::BorrowMut<[Item]> {
-    const SIZE: usize;
-}
-
-impl<Item> ArrayBuf<Item> for [Item; 24] {
-    const SIZE: usize = 24;
-}
-
-impl<Item> ArrayBuf<Item> for [Item; 12] {
-    const SIZE: usize = 12;
-}
-
 /// A circular buffer offering fixed-length continous views into data
 /// This is enabled by writing data twice, also to a "shadow"-buffer following the primary buffer,
 /// The tradeoff is writing all data twice, the gain is giving the compiler continuous view with
 /// predictable length into the data, unlocking some more optimizations
 #[derive(Clone, Debug)]
-struct RollingBuffer<A, T> {
+struct RollingBuffer<T, const N: usize> {
     buf: [T; TAPS],
     position: usize,
-    _phantom: std::marker::PhantomData<A>,
 }
 
-impl<A: ArrayBuf<T>, T: Default + Copy> RollingBuffer<A, T> {
+impl<T: Default + Copy, const N: usize> RollingBuffer<T, N> {
     fn new() -> Self {
-        assert!(A::SIZE * 2 <= TAPS);
+        assert!(N * 2 <= TAPS);
 
         let buf: [T; TAPS] = [Default::default(); TAPS];
 
-        Self {
-            buf,
-            position: A::SIZE,
-            _phantom: Default::default(),
-        }
+        Self { buf, position: N }
     }
 
     #[inline(always)]
     fn push_front(&mut self, v: T) {
         if self.position == 0 {
-            self.position = A::SIZE - 1;
+            self.position = N - 1;
         } else {
             self.position -= 1;
         }
+        // this is safe, since self.position is always kept below N, which is checked at creation
+        // to be `<= buf.size() / 2`
         unsafe {
             *self.buf.get_unchecked_mut(self.position) = v;
-            *self.buf.get_unchecked_mut(self.position + A::SIZE) = v;
+            *self.buf.get_unchecked_mut(self.position + N) = v;
         }
     }
 }
 
-impl<A, T> AsRef<A> for RollingBuffer<A, T> {
+impl<T, const N: usize> AsRef<[T; N]> for RollingBuffer<T, N> {
     #[inline(always)]
-    fn as_ref(&self) -> &A {
-        unsafe { &*(self.buf.get_unchecked(self.position) as *const T as *const A) }
+    fn as_ref(&self) -> &[T; N] {
+        // this is safe, since self.position is always kept below N, which is checked at creation
+        // to be `<= buf.size() / 2`
+        unsafe { &*(self.buf.get_unchecked(self.position) as *const T as *const [T; N]) }
     }
 }
 
-macro_rules! interp_impl {
-    ( $name:ident, $factor:expr ) => {
-        #[derive(Debug, Clone)]
-        pub struct $name<F: FrameAccumulator> {
-            filter: [[f32; $factor]; (TAPS / $factor)],
-            buffer: RollingBuffer<[F; TAPS / $factor], F>,
-        }
-
-        impl<F> Default for $name<F>
-        where
-            F: FrameAccumulator + Default,
-        {
-            fn default() -> Self {
-                Self::new()
-            }
-        }
-
-        impl<F> $name<F>
-        where
-            F: FrameAccumulator + Default,
-        {
-            pub fn new() -> Self {
-                let mut filter: [[_; $factor]; (TAPS / $factor)] = Default::default();
-                for (j, coeff) in filter
-                    .iter_mut()
-                    .map(|x| x.iter_mut())
-                    .flatten()
-                    .enumerate()
-                {
-                    let j = j as f64;
-                    // Calculate Hanning window,
-                    let window = TAPS + 1;
-                    // Ignore one tap. (Last tap is zero anyways, and we want to hit an even multiple of 48)
-                    let window = (window - 1) as f64;
-                    let w = 0.5 * (1.0 - f64::cos(2.0 * PI * j / window));
-
-                    // Calculate sinc and apply hanning window
-                    let m = j - window / 2.0;
-                    *coeff = if m.abs() > ALMOST_ZERO {
-                        w * f64::sin(m * PI / $factor as f64) / (m * PI / $factor as f64)
-                    } else {
-                        w
-                    } as f32;
-                }
-
-                Self {
-                    filter,
-                    buffer: RollingBuffer::new(),
-                }
-            }
-
-            pub fn interpolate(&mut self, frame: F) -> [F; $factor] {
-                // Write in Frames in reverse, to enable forward-scanning with filter
-                self.buffer.push_front(frame);
-
-                let mut output: [F; $factor] = Default::default();
-
-                let buf = self.buffer.as_ref();
-
-                for (filter_coeffs, input_frame) in Iterator::zip(self.filter.iter(), buf) {
-                    for (output_frame, coeff) in Iterator::zip(output.iter_mut(), filter_coeffs) {
-                        output_frame.scale_add(input_frame, *coeff);
-                    }
-                }
-
-                output
-            }
-
-            pub fn reset(&mut self) {
-                self.buffer = RollingBuffer::new();
-            }
-        }
-    };
+#[derive(Debug, Clone)]
+pub struct InterpF<const ACTIVE_TAPS: usize, const FACTOR: usize, F: FrameAccumulator> {
+    filter: [[f32; FACTOR]; ACTIVE_TAPS],
+    buffer: RollingBuffer<F, ACTIVE_TAPS>,
 }
 
-interp_impl!(Interp2F, 2);
-interp_impl!(Interp4F, 4);
+impl<const ACTIVE_TAPS: usize, const FACTOR: usize, F> Default for InterpF<ACTIVE_TAPS, FACTOR, F>
+where
+    F: FrameAccumulator + Default,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const ACTIVE_TAPS: usize, const FACTOR: usize, F> InterpF<ACTIVE_TAPS, FACTOR, F>
+where
+    F: FrameAccumulator + Default,
+{
+    pub fn new() -> Self {
+        assert_eq!(ACTIVE_TAPS * FACTOR, TAPS);
+
+        let mut filter: [[_; FACTOR]; ACTIVE_TAPS] = [[0f32; FACTOR]; ACTIVE_TAPS];
+        for (j, coeff) in filter.iter_mut().flat_map(|x| x.iter_mut()).enumerate() {
+            let j = j as f64;
+            // Calculate Hanning window,
+            let window = TAPS + 1;
+            // Ignore one tap. (Last tap is zero anyways, and we want to hit an even multiple of 48)
+            let window = (window - 1) as f64;
+            let w = 0.5 * (1.0 - f64::cos(2.0 * PI * j / window));
+
+            // Calculate sinc and apply hanning window
+            let m = j - window / 2.0;
+            *coeff = if m.abs() > ALMOST_ZERO {
+                w * f64::sin(m * PI / FACTOR as f64) / (m * PI / FACTOR as f64)
+            } else {
+                w
+            } as f32;
+        }
+
+        Self {
+            filter,
+            buffer: RollingBuffer::new(),
+        }
+    }
+
+    pub fn interpolate(&mut self, frame: F) -> [F; FACTOR] {
+        // Write in Frames in reverse, to enable forward-scanning with filter
+        self.buffer.push_front(frame);
+
+        let mut output: [F; FACTOR] = [Default::default(); FACTOR];
+
+        let buf = self.buffer.as_ref();
+
+        for (filter_coeffs, input_frame) in Iterator::zip(self.filter.iter(), buf) {
+            for (output_frame, coeff) in Iterator::zip(output.iter_mut(), filter_coeffs) {
+                output_frame.scale_add(input_frame, *coeff);
+            }
+        }
+
+        output
+    }
+
+    pub fn reset(&mut self) {
+        self.buffer = RollingBuffer::new();
+    }
+}
 
 #[cfg(feature = "c-tests")]
 use std::os::raw::c_void;
@@ -186,8 +162,8 @@ mod c_tests {
 
     fn process_rust(data_in: &[f32], data_out: &mut [f32], factor: usize, channels: usize) {
         macro_rules! process_specialized {
-            ( $interp:ident, $channels:expr ) => {{
-                let mut interp = $interp::new();
+            ( $factor:expr, $channels:expr ) => {{
+                let mut interp = InterpF::<{ TAPS / $factor }, $factor, [f32; $channels]>::new();
                 let (_, data_in, _) = unsafe { data_in.align_to::<[f32; $channels]>() };
                 let (_, data_out, _) = unsafe { data_out.align_to_mut::<[f32; $channels]>() };
                 for (input_frame, output_frames) in
@@ -199,8 +175,9 @@ mod c_tests {
         }
 
         macro_rules! process_generic {
-            ( $interp:ident, $channels:expr ) => {{
-                let mut interp = vec![$interp::<[f32; 1]>::new(); $channels];
+            ( $factor:expr, $channels:expr ) => {{
+                let mut interp =
+                    vec![InterpF::<{ TAPS / $factor }, $factor, [f32; 1]>::new(); $channels];
                 let frames = data_in.len() / channels;
                 for frame in 0..frames {
                     for channel in 0..$channels {
@@ -217,18 +194,18 @@ mod c_tests {
         }
 
         match (factor, channels) {
-            (2, 1) => process_specialized!(Interp2F, 1),
-            (2, 2) => process_specialized!(Interp2F, 2),
-            (2, 4) => process_specialized!(Interp2F, 4),
-            (2, 6) => process_specialized!(Interp2F, 6),
-            (2, 8) => process_specialized!(Interp2F, 8),
-            (4, 1) => process_specialized!(Interp4F, 1),
-            (4, 2) => process_specialized!(Interp4F, 2),
-            (4, 4) => process_specialized!(Interp4F, 4),
-            (4, 6) => process_specialized!(Interp4F, 6),
-            (4, 8) => process_specialized!(Interp4F, 8),
-            (2, c) => process_generic!(Interp2F, c),
-            (4, c) => process_generic!(Interp4F, c),
+            (2, 1) => process_specialized!(2, 1),
+            (2, 2) => process_specialized!(2, 2),
+            (2, 4) => process_specialized!(2, 4),
+            (2, 6) => process_specialized!(2, 6),
+            (2, 8) => process_specialized!(2, 8),
+            (4, 1) => process_specialized!(4, 1),
+            (4, 2) => process_specialized!(4, 2),
+            (4, 4) => process_specialized!(4, 4),
+            (4, 6) => process_specialized!(4, 6),
+            (4, 8) => process_specialized!(4, 8),
+            (2, c) => process_generic!(2, c),
+            (4, c) => process_generic!(4, c),
             _ => unimplemented!(),
         }
     }

--- a/src/true_peak.rs
+++ b/src/true_peak.rs
@@ -19,7 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-use crate::interp::{Interp2F, Interp4F};
+use crate::interp::InterpF;
 use crate::utils::{FrameAccumulator, Sample};
 use dasp_frame::Frame;
 use smallvec::{smallvec, SmallVec};
@@ -28,18 +28,18 @@ use UpsamplingScanner::*;
 
 #[derive(Debug)]
 enum UpsamplingScanner {
-    Mono2F(Interp2F<[f32; 1]>),
-    Stereo2F(Interp2F<[f32; 2]>),
-    Quad2F(Interp2F<[f32; 4]>),
-    Surround2F(Interp2F<[f32; 6]>),
-    OctoSurround2F(Interp2F<[f32; 8]>),
-    Mono4F(Interp4F<[f32; 1]>),
-    Stereo4F(Interp4F<[f32; 2]>),
-    Quad4F(Interp4F<[f32; 4]>),
-    Surround4F(Interp4F<[f32; 6]>),
-    OctoSurround4F(Interp4F<[f32; 8]>),
-    Generic2F(Box<[Interp2F<[f32; 1]>]>),
-    Generic4F(Box<[Interp4F<[f32; 1]>]>),
+    Mono2F(InterpF<24, 2, [f32; 1]>),
+    Stereo2F(InterpF<24, 2, [f32; 2]>),
+    Quad2F(InterpF<24, 2, [f32; 4]>),
+    Surround2F(InterpF<24, 2, [f32; 6]>),
+    OctoSurround2F(InterpF<24, 2, [f32; 8]>),
+    Mono4F(InterpF<12, 4, [f32; 1]>),
+    Stereo4F(InterpF<12, 4, [f32; 2]>),
+    Quad4F(InterpF<12, 4, [f32; 4]>),
+    Surround4F(InterpF<12, 4, [f32; 6]>),
+    OctoSurround4F(InterpF<12, 4, [f32; 8]>),
+    Generic2F(Box<[InterpF<24, 2, [f32; 1]>]>),
+    Generic4F(Box<[InterpF<12, 4, [f32; 1]>]>),
 }
 
 impl UpsamplingScanner {
@@ -57,18 +57,18 @@ impl UpsamplingScanner {
         };
 
         Some(match (channels as usize, interp_factor) {
-            (1, Factor::Two) => Mono2F(Interp2F::new()),
-            (2, Factor::Two) => Stereo2F(Interp2F::new()),
-            (4, Factor::Two) => Quad2F(Interp2F::new()),
-            (6, Factor::Two) => Surround2F(Interp2F::new()),
-            (8, Factor::Two) => OctoSurround2F(Interp2F::new()),
-            (1, Factor::Four) => Mono4F(Interp4F::new()),
-            (2, Factor::Four) => Stereo4F(Interp4F::new()),
-            (4, Factor::Four) => Quad4F(Interp4F::new()),
-            (6, Factor::Four) => Surround4F(Interp4F::new()),
-            (8, Factor::Four) => OctoSurround4F(Interp4F::new()),
-            (c, Factor::Two) => Generic2F(vec![Interp2F::new(); c].into()),
-            (c, Factor::Four) => Generic4F(vec![Interp4F::new(); c].into()),
+            (1, Factor::Two) => Mono2F(InterpF::new()),
+            (2, Factor::Two) => Stereo2F(InterpF::new()),
+            (4, Factor::Two) => Quad2F(InterpF::new()),
+            (6, Factor::Two) => Surround2F(InterpF::new()),
+            (8, Factor::Two) => OctoSurround2F(InterpF::new()),
+            (1, Factor::Four) => Mono4F(InterpF::new()),
+            (2, Factor::Four) => Stereo4F(InterpF::new()),
+            (4, Factor::Four) => Quad4F(InterpF::new()),
+            (6, Factor::Four) => Surround4F(InterpF::new()),
+            (8, Factor::Four) => OctoSurround4F(InterpF::new()),
+            (c, Factor::Two) => Generic2F(vec![InterpF::new(); c].into()),
+            (c, Factor::Four) => Generic4F(vec![InterpF::new(); c].into()),
         })
     }
 
@@ -141,8 +141,8 @@ impl UpsamplingScanner {
             Quad4F(interpolator) => interpolator.reset(),
             Surround4F(interpolator) => interpolator.reset(),
             OctoSurround4F(interpolator) => interpolator.reset(),
-            Generic2F(interpolators) => interpolators.iter_mut().for_each(Interp2F::reset),
-            Generic4F(interpolators) => interpolators.iter_mut().for_each(Interp4F::reset),
+            Generic2F(interpolators) => interpolators.iter_mut().for_each(InterpF::reset),
+            Generic4F(interpolators) => interpolators.iter_mut().for_each(InterpF::reset),
         }
     }
 }


### PR DESCRIPTION
In particular, we can avoid macros, the ArrayBuf-hack, and associated PhantomData. The net result should be code with less indirections, that is slightly easier to read and understand. (But performs the same)